### PR TITLE
Fixed new (old) toolbar hover

### DIFF
--- a/prettify.user.js
+++ b/prettify.user.js
@@ -71,7 +71,7 @@ if (options.oldBar) {
   style.innerHTML +=  "border-left: 1px solid #677344;";
   style.innerHTML += "}";
 
-  style.innerHTML += ".user_toolbar>ul>li:hover {";
+  style.innerHTML += ".user_toolbar>ul>li>a:hover {";
   style.innerHTML +=  "background: #97a964;";
   style.innerHTML +=  "background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #97a964), color-stop(100%, #8b9b5c));";
   style.innerHTML +=  "background: -webkit-linear-gradient(top, #97a964 0%, #8b9b5c 100%);";


### PR DESCRIPTION
On Chrome 58.0.3029.110 (macOS 10.11.6), when hovering, the backgrounds of the (old) toolbar buttons were dark gray instead of the proper background color.

![screenshot 2017-06-06 15 48 51](https://user-images.githubusercontent.com/2782749/26849070-c63eb064-4ad0-11e7-9a1b-c6daed1a73b6.png)

This fixes it by targeting the actual link (`<a>` ) instead of the list element (`<li>`).
